### PR TITLE
GITHUB_WEBHOOK_PAYLOAD to a large value -> argument list too long

### DIFF
--- a/util.go
+++ b/util.go
@@ -22,8 +22,6 @@ var (
 func runCmd(command string, payload []byte) error {
 	var cmd *exec.Cmd
 
-	b := bytes.NewBuffer(payload)
-	os.Setenv("GITHUB_WEBHOOK_PAYLOAD", string(payload))
 	if runtime.GOOS == "windows" {
 		cmd = exec.Command("cmd", "/c", command)
 	} else {
@@ -50,6 +48,7 @@ func runCmd(command string, payload []byte) error {
 
 	go func() {
 		defer stdin.Close()
+		b := bytes.NewBuffer(payload)
 		_, werr := b.WriteTo(stdin)
 		if perr, ok := werr.(*os.PathError); ok && perr.Err == syscall.EPIPE {
 			// ignore EPIPE


### PR DESCRIPTION
`time="2017-0x-xxTxx:xx:xx+xx:xx" level=error msg="fork/exec /bin/sh: argument list too long"` 😢 

remove `GITHUB_WEBHOOK_PAYLOAD`.