### PR TITLE
fix parse action method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Flags:
 event = "push"
 command = "/path/to/script"
 branch = "feature/*"
+# exclude_actions = ["deleted", "created"]
 
 [[hook]]
 event = "pull_request"

--- a/github.go
+++ b/github.go
@@ -121,13 +121,31 @@ func parseBranch(payload interface{}) string {
 	return branches[2]
 }
 
+// Note: https://developer.github.com/v3/activity/events/types/
+// Include action field: return action field
+// Not Incluade action field: return parse created, deleted, and forced field when push
 func parseAction(payload interface{}) string {
 	j := payload.(map[string]interface{})
-	if _, ok := j["action"]; !ok {
-		return ""
+
+	// include action field
+	if _, ok := j["action"]; ok {
+		return j["action"].(string)
 	}
 
-	return j["action"].(string)
+	// not include action field
+	if created, ok := j["created"]; ok && created.(bool) {
+		return "created"
+	}
+
+	if deleted, ok := j["deleted"]; ok && deleted.(bool) {
+		return "deleted"
+	}
+
+	if forced, ok := j["forced"]; ok && forced.(bool) {
+		return "forced"
+	}
+
+	return ""
 }
 
 func parsePullRequestStatus(payload interface{}) (string, string, string) {

--- a/github_test.go
+++ b/github_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func Test_parseAction(t *testing.T) {
+	type Test struct {
+		Title   string
+		Payload string
+		Output  string
+	}
+
+	tests := []Test{
+		Test{
+			Title:   "pull request event",
+			Payload: `{"action": "append", "number": 1}`,
+			Output:  "append",
+		},
+		Test{
+			Title:   "push created",
+			Payload: `{"created": true, "deleted": false, "forced": false}`,
+			Output:  "created",
+		},
+		Test{
+			Title:   "push deleted",
+			Payload: `{"created": false, "deleted": true, "forced": false}`,
+			Output:  "deleted",
+		},
+		Test{
+			Title:   "push forced",
+			Payload: `{"created": false, "deleted": false, "forced": true}`,
+			Output:  "forced",
+		},
+		Test{
+			Title:   "push deleted and forced",
+			Payload: `{"created": false, "deleted": true, "forced": true}`,
+			Output:  "deleted",
+		},
+		Test{
+			Title:   "other case: fork",
+			Payload: `{"forkee": {"id": 123456, "name": "foo"}}`,
+			Output:  "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Title, func(t *testing.T) {
+			var payload interface{}
+			if err := json.NewDecoder(strings.NewReader(test.Payload)).Decode(&payload); err != nil {
+				t.Fatal("error parse json")
+			}
+
+			if action := parseAction(payload); action != test.Output {
+				t.Errorf("error parse action. include:%s output:%s", test.Payload, test.Output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
日本語で失礼します

pushした際にbranchのdeleteの場合はskipさせたかったので

action fieldがないpush eventのstatusもeventとして取得できるようにしました
refs: https://developer.github.com/v3/activity/events/types/#pushevent

